### PR TITLE
fix: force redeployment of analyze.js

### DIFF
--- a/netlify/functions/analyze.js
+++ b/netlify/functions/analyze.js
@@ -1,3 +1,4 @@
+// File updated to ensure latest version is deployed.
 // Note: 'node-fetch' is a dependency that needs to be installed. const fetch = require('node-fetch');
 
 exports.handler = async (event) => { // 1. Check for POST request if (event.httpMethod !== 'POST') { return { statusCode: 405, body: 'Method Not Allowed' }; }


### PR DESCRIPTION
The deployed version of the `analyze.js` Netlify function was returning an "apiKey is not defined" error, even though the code in the repository was correct.

This suggests the deployed code was an outdated version. This commit adds a trivial comment to the top of the file to force a new deployment, ensuring the version with the correct API key handling is used.